### PR TITLE
Changing name of az aci up to az container app up

### DIFF
--- a/deploy-to-azure/azext_deploy_to_azure/dev/aci/_help.py
+++ b/deploy-to-azure/azext_deploy_to_azure/dev/aci/_help.py
@@ -7,13 +7,13 @@ from knack.help_files import helps
 
 
 def load_aci_help():
-    helps['aci'] = """
+    helps['container app'] = """
     type: group
     short-summary: Commands to Manage Azure Container Instances App
     long-summary:
     """
 
-    helps['aci up'] = """
+    helps['container app up'] = """
     type: command
     short-summary: Deploy to Azure Container Instances using GitHub Actions
     long-summary:

--- a/deploy-to-azure/azext_deploy_to_azure/dev/aci/arguments.py
+++ b/deploy-to-azure/azext_deploy_to_azure/dev/aci/arguments.py
@@ -5,5 +5,5 @@
 
 
 def load_aci_arguments(self, _):
-    with self.argument_context('aci up') as c:
+    with self.argument_context('container app up') as c:
         c.argument('repository', options_list=['--repository'])

--- a/deploy-to-azure/azext_deploy_to_azure/dev/aci/commands.py
+++ b/deploy-to-azure/azext_deploy_to_azure/dev/aci/commands.py
@@ -11,5 +11,5 @@ aciops = CliCommandType(
 
 
 def load_aci_commands(self, _):
-    with self.command_group('aci', command_type=aciops) as g:
+    with self.command_group('container app', command_type=aciops) as g:
         g.command('up', 'aci_up')


### PR DESCRIPTION
Changing the name of the command group `az aci up` to `az container app up` to match the syntax of az aks app up