### PR TITLE
Replace deprecated 'az configure' with 'az config'

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,4 +7,4 @@
  ### Enabling/Disabling Telemetry
 
 We inherit the telemetry settings from azure-cli.
-Run `az configure` to enable/disable data collection.
+Run `az config` to enable/disable data collection.


### PR DESCRIPTION
Replace instances of the deprecated 'az configure' with 'az config'.

This work is for story [1844036](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1844036). 
